### PR TITLE
Improve logging and handle camera errors on Android

### DIFF
--- a/ios/Classes/PluginHandler.swift
+++ b/ios/Classes/PluginHandler.swift
@@ -26,8 +26,6 @@ public class PluginHandler {
                 setSpeakerphoneOn(call, result: result)
             case "getSpeakerphoneOn":
                 getSpeakerphoneOn(result: result)
-            case "takePhoto":
-                takePhoto(call, result: result)
             case "LocalAudioTrack#enable":
                 localAudioTrackEnable(call, result: result)
             case "LocalDataTrack#sendString":
@@ -42,6 +40,8 @@ public class PluginHandler {
                 localVideoTrackFrameCount(call, result:result)
             case "CameraCapturer#switchCamera":
                 switchCamera(call, result: result)
+            case "CameraCapturer#takePhoto":
+                takePhoto(call, result: result)
             default:
                 result(FlutterMethodNotImplemented)
         }

--- a/lib/src/camera_capturer.dart
+++ b/lib/src/camera_capturer.dart
@@ -42,6 +42,14 @@ class CameraCapturer implements VideoCapturer {
     _updateFromMap(cameraCapturerMap);
   }
 
+  /// Takes a photo from the camera capturer.
+  Future<dynamic> takePhoto(int imageCompression) async {
+    final methodData = await MethodChannel('twilio_programmable_video')
+        .invokeMethod(
+            'CameraCapturer#takePhoto', {'imageCompression': imageCompression});
+    return methodData;
+  }
+
   /// Update properties from a map.
   @override
   void _updateFromMap(Map<String, dynamic> map) {

--- a/lib/src/programmable_video.dart
+++ b/lib/src/programmable_video.dart
@@ -58,11 +58,6 @@ class TwilioProgrammableVideo {
     return _methodChannel.invokeMethod('getSpeakerphoneOn');
   }
 
-  /// Takes a photo from the camera capturer.
-  static Future<dynamic> takePhoto(int imageCompression) async {
-    return _methodChannel.invokeMethod('takePhoto', {'imageCompression': imageCompression});
-  }
-
   /// Request permission for camera and microphone.
   ///
   /// Uses the PermissionHandler plugin. Returns the granted result.

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -120,7 +120,11 @@ class Room {
 
   /// Disconnects from the room.
   Future<void> disconnect() async {
-    await const MethodChannel('twilio_programmable_video').invokeMethod('disconnect');
+    await const MethodChannel('twilio_programmable_video')
+        .invokeMethod('disconnect');
+  }
+
+  void disposeRoom() async {
     await _roomStream.cancel();
     await _remoteParticipantStream.cancel();
     await _localParticipantStream.cancel();
@@ -213,6 +217,7 @@ class Room {
         }
         _remoteParticipants.clear();
         _onDisconnected.add(RoomDisconnectedEvent(this, twilioException));
+        disposeRoom();
         break;
       case 'participantConnected':
         assert(remoteParticipant != null);


### PR DESCRIPTION
Move the takePicture method onto the cameraCapturer channel to allow better logging on Android.
Add in extra logging and error checking when taking a picture on Android
Fix room disconnecting callbacks being cut off by the streams being disposed of on disconnect.