### PR TITLE
Move event exception null check to when needed

### DIFF
--- a/programmable_video/lib/src/exceptions/twilio_exception.dart
+++ b/programmable_video/lib/src/exceptions/twilio_exception.dart
@@ -81,6 +81,9 @@ class TwilioException implements Exception {
 
   /// Construct from a [TwilioExceptionModel].
   factory TwilioException._fromModel(TwilioExceptionModel model) {
+    if (model == null) {
+      return null;
+    }
     return TwilioException(model.code, model.message);
   }
 }

--- a/programmable_video/lib/src/room.dart
+++ b/programmable_video/lib/src/room.dart
@@ -177,12 +177,11 @@ class Room {
     }
     _updateFromModel(event.roomModel);
 
-    var twilioException = null;
-    if (event.exception != null) {
-      twilioException = TwilioException._fromModel(event.exception);
-    }
-
     if (event is ConnectFailure) {
+      var twilioException = null;
+      if (event.exception != null) {
+        twilioException = TwilioException._fromModel(event.exception);
+      }
       _onConnectFailure.add(RoomConnectFailureEvent(this, twilioException));
     } else if (event is Connected) {
       _onConnected.add(this);
@@ -191,6 +190,10 @@ class Room {
         participant._dispose();
       }
       _remoteParticipants.clear();
+      var twilioException = null;
+      if (event.exception != null) {
+        twilioException = TwilioException._fromModel(event.exception);
+      }
       _onDisconnected.add(RoomDisconnectedEvent(this, twilioException));
       disposeRoom();
     } else if (event is ParticipantConnected) {
@@ -212,6 +215,10 @@ class Room {
     } else if (event is Reconnected) {
       _onReconnected.add(this);
     } else if (event is Reconnecting) {
+      var twilioException = null;
+      if (event.exception != null) {
+        twilioException = TwilioException._fromModel(event.exception);
+      }
       _onReconnecting.add(RoomReconnectingEvent(this, twilioException));
     } else if (event is RecordingStarted) {
       _onRecordingStarted.add(this);

--- a/programmable_video/lib/src/room.dart
+++ b/programmable_video/lib/src/room.dart
@@ -178,11 +178,7 @@ class Room {
     _updateFromModel(event.roomModel);
 
     if (event is ConnectFailure) {
-      var twilioException = null;
-      if (event.exception != null) {
-        twilioException = TwilioException._fromModel(event.exception);
-      }
-      _onConnectFailure.add(RoomConnectFailureEvent(this, twilioException));
+      _onConnectFailure.add(RoomConnectFailureEvent(this, TwilioException._fromModel(event.exception)));
     } else if (event is Connected) {
       _onConnected.add(this);
     } else if (event is Disconnected) {
@@ -190,11 +186,7 @@ class Room {
         participant._dispose();
       }
       _remoteParticipants.clear();
-      var twilioException = null;
-      if (event.exception != null) {
-        twilioException = TwilioException._fromModel(event.exception);
-      }
-      _onDisconnected.add(RoomDisconnectedEvent(this, twilioException));
+      _onDisconnected.add(RoomDisconnectedEvent(this, TwilioException._fromModel(event.exception)));
       disposeRoom();
     } else if (event is ParticipantConnected) {
       assert(event.connectedParticipant != null);
@@ -215,11 +207,7 @@ class Room {
     } else if (event is Reconnected) {
       _onReconnected.add(this);
     } else if (event is Reconnecting) {
-      var twilioException = null;
-      if (event.exception != null) {
-        twilioException = TwilioException._fromModel(event.exception);
-      }
-      _onReconnecting.add(RoomReconnectingEvent(this, twilioException));
+      _onReconnecting.add(RoomReconnectingEvent(this, TwilioException._fromModel(event.exception)));
     } else if (event is RecordingStarted) {
       _onRecordingStarted.add(this);
     } else if (event is RecordingStopped) {


### PR DESCRIPTION
When trying to access the exception getter for an event type that
does not have an exception, an error occurs.