### PR TITLE
Temporarily disable Camera2Capturer

### DIFF
--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
@@ -144,6 +144,7 @@ class PluginHandler : MethodCallHandler, ActivityAware, BaseListener {
             getLocalParticipant()?.publishTrack(localVideoTrack.localVideoTrack)
             return result.success(true)
         }
+        TwilioProgrammableVideoPlugin.debug("No LocalVideoTrack found or LocalVideoTrack already released while resetting video")
         return result.success(false)
     }
 

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
@@ -139,7 +139,7 @@ class PluginHandler : MethodCallHandler, ActivityAware, BaseListener {
     private fun localParticipantResetVideo(call: MethodCall, result: MethodChannel.Result) {
         TwilioProgrammableVideoPlugin.debug("PluginHandler.localParticipantResetVideo => called")
         val localVideoTrack = getLocalParticipant()?.localVideoTracks?.firstOrNull()
-        if (localVideoTrack != null && localVideoTrack.localVideoTrack.isEnabled) {
+        if (localVideoTrack != null && localVideoTrack.isTrackEnabled) {
             getLocalParticipant()?.unpublishTrack(localVideoTrack.localVideoTrack)
             getLocalParticipant()?.publishTrack(localVideoTrack.localVideoTrack)
             return result.success(true)

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
@@ -139,12 +139,12 @@ class PluginHandler : MethodCallHandler, ActivityAware, BaseListener {
     private fun localParticipantResetVideo(call: MethodCall, result: MethodChannel.Result) {
         TwilioProgrammableVideoPlugin.debug("PluginHandler.localParticipantResetVideo => called")
         val localVideoTrack = getLocalParticipant()?.localVideoTracks?.firstOrNull()
-        if (localVideoTrack != null) {
+        if (localVideoTrack != null && localVideoTrack.localVideoTrack.isEnabled) {
             getLocalParticipant()?.unpublishTrack(localVideoTrack.localVideoTrack)
             getLocalParticipant()?.publishTrack(localVideoTrack.localVideoTrack)
             return result.success(true)
         }
-        return result.error("NOT_FOUND", "No LocalVideoTrack found", null)
+        return result.success(false)
     }
 
     private fun localVideoTrackEnable(call: MethodCall, result: MethodChannel.Result) {

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/VideoCapturerHandler.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/VideoCapturerHandler.kt
@@ -16,11 +16,14 @@ class VideoCapturerHandler {
     companion object {
         @JvmStatic
         fun initializeCapturer(videoCapturerMap: Map<*, *>, result: MethodChannel.Result) {
+            /* TODO: Fix our photo capture renderer to work with Camera2Capturer
             if (Camera2Capturer.isSupported(TwilioProgrammableVideoPlugin.pluginHandler.applicationContext)) {
                 initializeCamera2Capturer(videoCapturerMap, result)
             } else {
                 initializeCameraCapturer(videoCapturerMap, result)
             }
+            */
+            initializeCameraCapturer(videoCapturerMap, result)
         }
 
         @JvmStatic


### PR DESCRIPTION
Camera2Capturer is not compatible with our photo capture renderer.

Also, fixed a minor issue with reset video causing an error when
disconnecting.