### PR TITLE
Re-enable and support Android camera2 capturer

### DIFF
--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/DataOnlyTextureBuffer.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/DataOnlyTextureBuffer.kt
@@ -1,0 +1,40 @@
+package twilio.flutter.twilio_programmable_video
+
+import android.graphics.Matrix
+import tvi.webrtc.VideoFrame
+
+class DataOnlyTextureBuffer(
+        private val width: Int,
+        private val height: Int,
+        private val type: VideoFrame.TextureBuffer.Type,
+        private val matrix: Matrix,
+        private val textureId: Int
+) : VideoFrame.TextureBuffer {
+    override fun getTextureId(): Int {
+        return textureId
+    }
+
+    override fun getHeight(): Int {
+        return height
+    }
+
+    override fun getType(): VideoFrame.TextureBuffer.Type {
+        return type
+    }
+
+    override fun getWidth(): Int {
+        return width
+    }
+
+    override fun getTransformMatrix(): Matrix {
+        return matrix
+    }
+
+    override fun toI420(): VideoFrame.I420Buffer { throw NotImplementedError() }
+
+    override fun retain() { throw NotImplementedError() }
+
+    override fun cropAndScale(p0: Int, p1: Int, p2: Int, p3: Int, p4: Int, p5: Int): VideoFrame.Buffer { throw NotImplementedError() }
+
+    override fun release() { throw NotImplementedError() }
+}

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/ParticipantViewFactory.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/ParticipantViewFactory.kt
@@ -33,12 +33,12 @@ class ParticipantViewFactory(createArgsCodec: MessageCodec<Any>, private val plu
             }
 
             if (videoTrack != null) {
-                val videoView: VideoView = if (videoTrack is LocalVideoTrack) {
+                val videoView: VideoView = if (videoTrack is LocalVideoTrack && plugin.getAllowCamera2()) {
                     // If this is the local video track, we want to provide the frame to the plugin handler for taking photo requests.
                     object: VideoView(context) {
                         override fun renderFrame(frame: I420Frame) {
-                            super.renderFrame(frame)
                             plugin.onRenderFrame(frame)
+                            super.renderFrame(frame)
                         }
                     }
                 } else {

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/ParticipantViewFactory.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/ParticipantViewFactory.kt
@@ -1,6 +1,8 @@
 package twilio.flutter.twilio_programmable_video
 
 import android.content.Context
+import com.twilio.video.I420Frame
+import com.twilio.video.LocalVideoTrack
 import com.twilio.video.VideoTrack
 import com.twilio.video.VideoView
 import io.flutter.plugin.common.MessageCodec
@@ -31,7 +33,17 @@ class ParticipantViewFactory(createArgsCodec: MessageCodec<Any>, private val plu
             }
 
             if (videoTrack != null) {
-                val videoView = VideoView(context)
+                val videoView: VideoView = if (videoTrack is LocalVideoTrack) {
+                    // If this is the local video track, we want to provide the frame to the plugin handler for taking photo requests.
+                    object: VideoView(context) {
+                        override fun renderFrame(frame: I420Frame) {
+                            super.renderFrame(frame)
+                            plugin.onRenderFrame(frame)
+                        }
+                    }
+                } else {
+                    VideoView(context)
+                }
                 videoView.mirror = params["mirror"] as Boolean
                 return ParticipantView(videoView, videoTrack)
             }

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
@@ -152,7 +152,7 @@ class PluginHandler : MethodCallHandler, ActivityAware, BaseListener {
                     val quality = call.argument<Int>("imageCompression") ?: 100
                     val nv21Data = YuvUtils.createNV21Data(i420Buffer)
                     val jpegData = YuvUtils.createJPEGData(nv21Data, i420Buffer.width, i420Buffer.height, quality)
-                    TwilioProgrammableVideoPlugin.debug("PluginHandler.takePhoto => Photo data size: ${jpegData.size}")
+                    TwilioProgrammableVideoPlugin.debug("PluginHandler.onRenderFrame => Photo data size: ${jpegData.size}")
                     result.success(jpegData)
                 } else {
                     result.error("ERROR", "Photo data is empty", null)

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
@@ -19,15 +19,12 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import tvi.webrtc.MediaCodecVideoEncoder
-import tvi.webrtc.voiceengine.WebRtcAudioUtils
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
-import kotlin.collections.ArrayList
-import kotlin.collections.component1
+import tvi.webrtc.voiceengine.WebRtcAudioUtils
 
 class PluginHandler : MethodCallHandler, ActivityAware, BaseListener {
     private data class TakePhotoRequest(val call: MethodCall, val result: MethodChannel.Result)
@@ -376,21 +373,12 @@ class PluginHandler : MethodCallHandler, ActivityAware, BaseListener {
                 val preferredVideoCodecs = optionsObj["preferredVideoCodecs"] as Map<*, *>
 
                 val videoCodecs = ArrayList<VideoCodec>()
-                // Some Android devices have issues rendering some resolutions on H264
-                // As per: https://bugs.chromium.org/p/webrtc/issues/detail?id=11337
-                // Force VP8 then turn off Hardware Encoding.
-                // Once Twilio update their version of WebRTC to include this bug fix we can remove this.
-                if (TwilioProgrammableVideoPlugin.HARDWARE_H264_BLACKLIST.contains(Build.MODEL) && !allowCamera2) {
-                    videoCodecs.add(Vp8Codec())
-                    MediaCodecVideoEncoder.disableVp8HwCodec()
-                } else {
-                    for ((videoCodec) in preferredVideoCodecs) {
-                        when (videoCodec) {
-                            Vp8Codec.NAME -> videoCodecs.add(Vp8Codec()) // TODO(WLFN): It has an optional parameter, need to figure out for what: https://github.com/twilio/video-quickstart-android/blob/master/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt#L106
-                            Vp9Codec.NAME -> videoCodecs.add(Vp9Codec())
-                            H264Codec.NAME -> videoCodecs.add(H264Codec())
-                            else -> videoCodecs.add(Vp8Codec())
-                        }
+                for ((videoCodec) in preferredVideoCodecs) {
+                    when (videoCodec) {
+                        Vp8Codec.NAME -> videoCodecs.add(Vp8Codec()) // TODO(WLFN): It has an optional parameter, need to figure out for what: https://github.com/twilio/video-quickstart-android/blob/master/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt#L106
+                        Vp9Codec.NAME -> videoCodecs.add(Vp9Codec())
+                        H264Codec.NAME -> videoCodecs.add(H264Codec())
+                        else -> videoCodecs.add(Vp8Codec())
                     }
                 }
                 TwilioProgrammableVideoPlugin.debug("PluginHandler.connect => setting videoCodecs to '${videoCodecs.joinToString(", ")}'")

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
@@ -152,6 +152,7 @@ class PluginHandler : MethodCallHandler, ActivityAware, BaseListener {
                     val quality = call.argument<Int>("imageCompression") ?: 100
                     val nv21Data = YuvUtils.createNV21Data(i420Buffer)
                     val jpegData = YuvUtils.createJPEGData(nv21Data, i420Buffer.width, i420Buffer.height, quality)
+                    TwilioProgrammableVideoPlugin.debug("PluginHandler.takePhoto => Photo data size: ${jpegData.size}")
                     result.success(jpegData)
                 } else {
                     result.error("ERROR", "Photo data is empty", null)

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/PluginHandler.kt
@@ -330,12 +330,15 @@ class PluginHandler : MethodCallHandler, ActivityAware, BaseListener {
         val optionsObj = call.argument<Map<String, Any>>("connectOptions")
             ?: return result.error("MISSING_PARAMS", "Missing 'connectOptions' parameter", null)
 
-        allowCamera2 = call.argument<Boolean>("allowCamera2") ?: false
-
         setAudioFocus(true)
 
         try {
             val optionsBuilder = ConnectOptions.Builder(optionsObj["accessToken"] as String)
+
+            if (optionsObj["allowCamera2"] != null && optionsObj["allowCamera2"] is Boolean) {
+                TwilioProgrammableVideoPlugin.debug("PluginHandler.connect => setting allowCamera2 to '${optionsObj["allowCamera2"]}'")
+                allowCamera2 = optionsObj["allowCamera2"] as Boolean
+            }
 
             // Set the room name if it has been passed.
             if (optionsObj["roomName"] != null) {

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/TwilioProgrammableVideoPlugin.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/TwilioProgrammableVideoPlugin.kt
@@ -70,17 +70,6 @@ class TwilioProgrammableVideoPlugin : FlutterPlugin {
 
         lateinit var pluginHandler: PluginHandler
 
-        @JvmStatic
-        val HARDWARE_H264_BLACKLIST = hashSetOf(
-                "Pixel 3",
-                "Pixel 3a",
-                "Pixel 3 XL",
-                "Pixel 4",
-                "Pixel 4a",
-                "Pixel 4 XL",
-                "Pixel 5"
-        )
-
         lateinit var roomListener: RoomListener
 
         lateinit var cameraCapturer: VideoCapturer

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/TwilioProgrammableVideoPlugin.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/TwilioProgrammableVideoPlugin.kt
@@ -70,6 +70,17 @@ class TwilioProgrammableVideoPlugin : FlutterPlugin {
 
         lateinit var pluginHandler: PluginHandler
 
+        @JvmStatic
+        val HARDWARE_H264_BLACKLIST = hashSetOf(
+                "Pixel 3",
+                "Pixel 3a",
+                "Pixel 3 XL",
+                "Pixel 4",
+                "Pixel 4a",
+                "Pixel 4 XL",
+                "Pixel 5"
+        )
+
         lateinit var roomListener: RoomListener
 
         lateinit var cameraCapturer: VideoCapturer

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/VideoCapturerHandler.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/VideoCapturerHandler.kt
@@ -16,14 +16,11 @@ class VideoCapturerHandler {
     companion object {
         @JvmStatic
         fun initializeCapturer(videoCapturerMap: Map<*, *>, result: MethodChannel.Result) {
-            /* TODO: Fix our photo capture renderer to work with Camera2Capturer
             if (Camera2Capturer.isSupported(TwilioProgrammableVideoPlugin.pluginHandler.applicationContext)) {
                 initializeCamera2Capturer(videoCapturerMap, result)
             } else {
                 initializeCameraCapturer(videoCapturerMap, result)
             }
-            */
-            initializeCameraCapturer(videoCapturerMap, result)
         }
 
         @JvmStatic

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/VideoCapturerHandler.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/VideoCapturerHandler.kt
@@ -15,8 +15,8 @@ import io.flutter.plugin.common.MethodChannel
 class VideoCapturerHandler {
     companion object {
         @JvmStatic
-        fun initializeCapturer(videoCapturerMap: Map<*, *>, result: MethodChannel.Result) {
-            if (Camera2Capturer.isSupported(TwilioProgrammableVideoPlugin.pluginHandler.applicationContext)) {
+        fun initializeCapturer(videoCapturerMap: Map<*, *>, result: MethodChannel.Result, allowCamera2: Boolean = false) {
+            if (Camera2Capturer.isSupported(TwilioProgrammableVideoPlugin.pluginHandler.applicationContext) && allowCamera2) {
                 initializeCamera2Capturer(videoCapturerMap, result)
             } else {
                 initializeCameraCapturer(videoCapturerMap, result)

--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/YuvUtils.java
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/YuvUtils.java
@@ -1,0 +1,134 @@
+package twilio.flutter.twilio_programmable_video;
+
+import android.graphics.ImageFormat;
+import android.graphics.Matrix;
+import android.graphics.Rect;
+import android.graphics.YuvImage;
+import android.opengl.EGL14;
+import android.opengl.EGLContext;
+import android.opengl.EGLDisplay;
+import android.view.Surface;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.twilio.video.I420Frame;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+
+import tvi.webrtc.EglBase;
+import tvi.webrtc.JavaI420Buffer;
+import tvi.webrtc.RendererCommon;
+import tvi.webrtc.SurfaceTextureHelper;
+import tvi.webrtc.VideoFrame;
+import tvi.webrtc.YuvHelper;
+
+public class YuvUtils {
+    private static final int I420_Y = 0;
+    private static final int I420_U = 1;
+    private static final int I420_V = 2;
+
+    /**
+     * Creates an NV21 buffer from an I420 buffer.<br/>
+     * Code taken from https://chromium.googlesource.com/external/webrtc/+/refs/heads/master/sdk/android/instrumentationtests/src/org/webrtc/VideoFrameBufferTest.java
+     * @param i420Buffer An I420Buffer from WebRTC.
+     * @return A byte array containing NV21 data.
+     */
+    @NonNull
+    static byte[] createNV21Data(@NonNull VideoFrame.I420Buffer i420Buffer) {
+        final int width = i420Buffer.getWidth();
+        final int height = i420Buffer.getHeight();
+        final int chromaStride = width;
+        final int chromaWidth = (width + 1) / 2;
+        final int chromaHeight = (height + 1) / 2;
+        final int ySize = width * height;
+        final ByteBuffer nv21Buffer = ByteBuffer.allocateDirect(ySize + chromaStride * chromaHeight);
+        final byte[] nv21Data = nv21Buffer.array();
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                final byte yValue = i420Buffer.getDataY().get(y * i420Buffer.getStrideY() + x);
+                nv21Data[y * width + x] = yValue;
+            }
+        }
+        for (int y = 0; y < chromaHeight; ++y) {
+            for (int x = 0; x < chromaWidth; ++x) {
+                final byte uValue = i420Buffer.getDataU().get(y * i420Buffer.getStrideU() + x);
+                final byte vValue = i420Buffer.getDataV().get(y * i420Buffer.getStrideV() + x);
+                nv21Data[ySize + y * chromaStride + 2 * x + 0] = vValue;
+                nv21Data[ySize + y * chromaStride + 2 * x + 1] = uValue;
+            }
+        }
+        return nv21Data;
+    }
+
+    @Nullable
+    static VideoFrame.I420Buffer createI420Buffer(@NonNull I420Frame frame) {
+        if (frame.yuvPlanes != null && frame.yuvStrides != null) {
+            ByteBuffer dstY = ByteBuffer.allocateDirect(frame.yuvPlanes[I420_Y].capacity());
+            ByteBuffer dstU = ByteBuffer.allocateDirect(frame.yuvPlanes[I420_U].capacity());
+            ByteBuffer dstV = ByteBuffer.allocateDirect(frame.yuvPlanes[I420_V].capacity());
+            int dstStrideY = frame.yuvStrides[I420_Y];
+            int dstStrideU = frame.yuvStrides[I420_U];
+            int dstStrideV = frame.yuvStrides[I420_V];
+            YuvHelper.I420Copy(
+                    frame.yuvPlanes[I420_Y],
+                    frame.yuvStrides[I420_Y],
+                    frame.yuvPlanes[I420_U],
+                    frame.yuvStrides[I420_U],
+                    frame.yuvPlanes[I420_V],
+                    frame.yuvStrides[I420_V],
+                    dstY,
+                    dstStrideY,
+                    dstU,
+                    dstStrideU,
+                    dstV,
+                    dstStrideV,
+                    frame.width,
+                    frame.height
+            );
+            return JavaI420Buffer.wrap(
+                    frame.width,
+                    frame.height,
+                    dstY,
+                    dstStrideY,
+                    dstU,
+                    dstStrideU,
+                    dstV,
+                    dstStrideV,
+                    null
+            );
+        } else if (frame.samplingMatrix != null && frame.textureId > 0) {
+            SurfaceTextureHelper surfaceTextureHelper = getSurfaceTextureHelper();
+            if (surfaceTextureHelper != null) {
+                Matrix matrix = RendererCommon.convertMatrixToAndroidGraphicsMatrix(frame.samplingMatrix);
+                VideoFrame.TextureBuffer textureBuffer = new DataOnlyTextureBuffer(frame.width, frame.height, VideoFrame.TextureBuffer.Type.OES, matrix, frame.textureId);
+                return surfaceTextureHelper.textureToYuv(textureBuffer);
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    @NonNull
+    static byte[] createJPEGData(@NonNull byte[] nv21Data, int width, int height, int quality) {
+        YuvImage yuvImage = new YuvImage(nv21Data, ImageFormat.NV21, width, height,null);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        yuvImage.compressToJpeg(new Rect(0, 0, width, height), quality, out);
+        return out.toByteArray();
+    }
+
+    private static SurfaceTextureHelper getSurfaceTextureHelper() {
+        try {
+            Field f = TwilioProgrammableVideoPlugin.cameraCapturer.getClass().getDeclaredField("surfaceTextureHelper");
+            f.setAccessible(true);
+            return (SurfaceTextureHelper) f.get(TwilioProgrammableVideoPlugin.cameraCapturer);
+        } catch (Exception e) {
+            TwilioProgrammableVideoPlugin.debug("Unable to access surfaceTextureHelper");
+        }
+        return null;
+    }
+}

--- a/programmable_video/lib/src/connect_options.dart
+++ b/programmable_video/lib/src/connect_options.dart
@@ -47,6 +47,8 @@ class ConnectOptions {
   /// Choosing between `subscribe-to-all` or `subscribe-to-none` subscription rule
   final bool enableAutomaticSubscription;
 
+  final bool allowCamera2;
+
   ConnectOptions(
     this.accessToken, {
     this.audioTracks,
@@ -60,6 +62,7 @@ class ConnectOptions {
     this.networkQualityConfiguration,
     this.enableDominantSpeaker,
     this.enableAutomaticSubscription,
+    this.allowCamera2 = false,
   })  : assert(accessToken != null),
         assert(accessToken.isNotEmpty),
         assert((audioTracks != null && audioTracks.isNotEmpty) || audioTracks == null),
@@ -108,6 +111,7 @@ class ConnectOptions {
       roomName: roomName,
       enableNetworkQuality: enableNetworkQuality,
       networkQualityConfiguration: networkQualityConfiguration?._toModel(),
+      allowCamera2: allowCamera2,
     );
   }
 }

--- a/programmable_video_platform_interface/lib/src/models/connect_options_model.dart
+++ b/programmable_video_platform_interface/lib/src/models/connect_options_model.dart
@@ -46,6 +46,8 @@ class ConnectOptionsModel {
   /// Network Quality API.
   final NetworkQualityConfigurationModel networkQualityConfiguration;
 
+  final bool allowCamera2;
+
   ConnectOptionsModel(
     this.accessToken, {
     this.audioTracks,
@@ -59,6 +61,7 @@ class ConnectOptionsModel {
     this.enableAutomaticSubscription,
     this.enableNetworkQuality,
     this.networkQualityConfiguration,
+    this.allowCamera2,
   })  : assert(accessToken != null),
         assert(accessToken.isNotEmpty),
         assert((audioTracks != null && audioTracks.isNotEmpty) || audioTracks == null),
@@ -84,7 +87,8 @@ class ConnectOptionsModel {
         'enableDominantSpeaker': enableDominantSpeaker,
         'enableAutomaticSubscription': enableAutomaticSubscription,
         'enableNetworkQuality': enableNetworkQuality,
-        'networkQualityConfiguration': networkQualityConfiguration != null ? networkQualityConfiguration.toMap() : null
+        'networkQualityConfiguration': networkQualityConfiguration != null ? networkQualityConfiguration.toMap() : null,
+        'allowCamera2': allowCamera2
       },
     };
   }


### PR DESCRIPTION
Rewritten our take photo logic to work with camera2 capturer.
Also, fixed a bug with calculating video constraints.